### PR TITLE
Embed icons directly

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -63,12 +63,9 @@ func (s *service) definition(canvas *svg.SVG, iconsRendered map[string]bool, ico
 	iconsRendered[s.charmPath] = true
 	iconIds[s.charmPath] = fmt.Sprintf("icon-%d", len(iconsRendered))
 
-	canvas.Group(fmt.Sprintf(`id=%q`, iconIds[s.charmPath]))
-	defer canvas.Gend()
-
 	// Temporary solution:
 	iconBuf := bytes.NewBuffer(s.iconSrc)
-	return processIcon(iconBuf, canvas.Writer)
+	return processIcon(iconBuf, canvas.Writer, iconIds[s.charmPath])
 }
 
 // usage creates any necessary tags for actually using the service in the SVG.

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -53,9 +53,7 @@ func (s *CanvasSuite) TestServiceRender(c *gc.C) {
 				},
 				iconSrc: []byte("<svg>bar</svg>"),
 			},
-			expected: `<g id="icon-1" >
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg">bar</svg:svg></g>
-<use x="0" y="0" xlink:href="#serviceBlock" id="bar" />
+			expected: `<svg:svg xmlns:svg="http://www.w3.org/2000/svg" id="icon-1">bar</svg:svg><use x="0" y="0" xlink:href="#serviceBlock" id="bar" />
 <use x="46" y="46" xlink:href="#icon-1" width="96" height="96" />
 <g style="font-size:18px;fill:#505050;text-anchor:middle">
 <text x="94" y="31" >bar</text>
@@ -207,11 +205,9 @@ func (s *CanvasSuite) TestMarshal(c *gc.C) {
 <circle cx="10" cy="10" r="10" style="stroke:#38B44A;fill:none;stroke-width:2px"/>
 <circle cx="10" cy="10" r="5" style="fill:#38B44A"/>
 </g>
-<g id="icon-1" >
-<svg xmlns="http://www.w3.org/2000/svg" class="blah">
+<svg xmlns="http://www.w3.org/2000/svg" class="blah" id="icon-1">
 <circle cx="20" cy="20" r="20" style="fill:#000"></circle>
 </svg>
-</g>
 </defs>
 <g id="relations">
 <line x1="94" y1="189" x2="100" y2="194" stroke="#38B44A" stroke-width="2px" stroke-dasharray="-6.09, 20" />

--- a/examples/generatesvg.go
+++ b/examples/generatesvg.go
@@ -18,7 +18,7 @@ import (
 // iconURL takes a reference to a charm and returns the URL for that charm's icon.
 // In this case, we're using the api.jujucharms.com API to provide the icon's URL.
 func iconURL(ref *charm.Reference) string {
-	return "https://api.jujucharms.com/v4/" + ref.Path() + "/icon.svg"
+	return "https://api.jujucharms.com/charmstore/v4/" + ref.Path() + "/icon.svg"
 }
 
 func main() {

--- a/examples/generatesvg.go
+++ b/examples/generatesvg.go
@@ -18,7 +18,7 @@ import (
 // iconURL takes a reference to a charm and returns the URL for that charm's icon.
 // In this case, we're using the api.jujucharms.com API to provide the icon's URL.
 func iconURL(ref *charm.Reference) string {
-	return "https://api.jujucharms.com/v4/" + ref.Path() + "/archive/icon.svg"
+	return "https://api.jujucharms.com/v4/" + ref.Path() + "/icon.svg"
 }
 
 func main() {
@@ -40,8 +40,7 @@ func main() {
 	}
 
 	fetcher := &jujusvg.HTTPFetcher{
-		IconURL:        iconURL,
-		DefaultIconURL: "https://jujucharms.com/static/img/icons/default-charm.svg",
+		IconURL: iconURL,
 	}
 	// Next, build a canvas of the bundle.  This is a simplified version of a charm.Bundle
 	// that contains just the position information and charm icon URLs necessary to build

--- a/examples/generatesvg.go
+++ b/examples/generatesvg.go
@@ -39,10 +39,14 @@ func main() {
 		log.Fatalf("Error parsing bundle: %s\n", err)
 	}
 
+	fetcher := &jujusvg.HTTPFetcher{
+		IconURL:        iconURL,
+		DefaultIconURL: "https://jujucharms.com/static/img/icons/default-charm.svg",
+	}
 	// Next, build a canvas of the bundle.  This is a simplified version of a charm.Bundle
 	// that contains just the position information and charm icon URLs necessary to build
 	// the SVG representation of the bundle
-	canvas, err := jujusvg.NewFromBundle(bundle, iconURL, nil)
+	canvas, err := jujusvg.NewFromBundle(bundle, iconURL, fetcher)
 	if err != nil {
 		log.Fatalf("Error generating canvas: %s\n", err)
 	}

--- a/examples/kubernetes-bundle.yaml
+++ b/examples/kubernetes-bundle.yaml
@@ -1,0 +1,44 @@
+services:
+  "kubernetes-master":
+    charm: cs:~kubernetes/trusty/kubernetes-master-5
+    annotations:
+      "gui-x": "600"
+      "gui-y": "0"
+    expose: true
+  docker:
+    charm: cs:trusty/docker-2
+    num_units: 2
+    annotations:
+      "gui-x": "0"
+      "gui-y": "0"
+  flannel-docker:
+    charm: cs:trusty/flannel-docker-5
+    annotations:
+      "gui-x": "0"
+      "gui-y": "300"
+  kubernetes:
+    charm: cs:~kubernetes/trusty/kubernetes-5
+    annotations:
+      "gui-x": "300"
+      "gui-y": "300"
+  etcd:
+    charm: cs:~kubernetes/trusty/etcd-2
+    annotations:
+      "gui-x": "300"
+      "gui-y": "0"
+relations:
+  - - "flannel-docker:network"
+    - "docker:network"
+  - - "flannel-docker:docker-host"
+    - "docker:juju-info"
+  - - "flannel-docker:db"
+    - "etcd:client"
+  - - "kubernetes:docker-host"
+    - "docker:juju-info"
+  - - "etcd:client"
+    - "kubernetes:etcd"
+  - - "etcd:client"
+    - "kubernetes-master:etcd"
+  - - "kubernetes-master:minions-api"
+    - "kubernetes:api"
+series: trusty

--- a/iconfetcher.go
+++ b/iconfetcher.go
@@ -71,10 +71,6 @@ type HTTPFetcher struct {
 	// makes this method nominally synchronous.
 	Concurrency int
 
-	// If provided, use this as the icon URL if a charm does not have an icon
-	// provided by the IconURL method.
-	DefaultIconURL string
-
 	// IconURL returns the URL from which to fetch the given entity's icon SVG.
 	IconURL func(*charm.Reference) string
 
@@ -133,14 +129,7 @@ func (h *HTTPFetcher) fetchIcon(url string, client *http.Client) ([]byte, error)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusNotFound && h.DefaultIconURL != "" {
-			resp, err = client.Get(h.DefaultIconURL)
-			if err != nil {
-				return nil, errgo.Notef(err, "HTTP error fetching %s: %v", h.DefaultIconURL, err)
-			}
-		} else {
-			return nil, errgo.Newf("cannot retrieve icon from %s: %s", url, resp.Status)
-		}
+		return nil, errgo.Newf("cannot retrieve icon from %s: %s", url, resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/iconfetcher_test.go
+++ b/iconfetcher_test.go
@@ -89,7 +89,47 @@ func (s *IconFetcherSuite) TestHTTPFetchIcons(c *gc.C) {
 	c.Assert(fetchCount, gc.Equals, 6)
 }
 
-func (s *IconFetcherSuite) TestHttpBadIconURL(c *gc.C) {
+func (s *IconFetcherSuite) TestHTTPDefaultIconUrl(c *gc.C) {
+	alreadyFetched := false
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if !alreadyFetched {
+			http.Error(w, "bad-wolf", http.StatusNotFound)
+			alreadyFetched = true
+			return
+		}
+		fmt.Fprint(w, "<svg>default</svg>\n")
+	}))
+	defer ts.Close()
+
+	tsIconURL := func(ref *charm.Reference) string {
+		return ts.URL + "/" + ref.Path() + ".svg"
+	}
+
+	b, err := charm.ReadBundleData(strings.NewReader(bundle))
+	c.Assert(err, gc.IsNil)
+	err = b.Verify(nil)
+	c.Assert(err, gc.IsNil)
+	fetcher := HTTPFetcher{
+		Concurrency:    1,
+		IconURL:        tsIconURL,
+		DefaultIconURL: fmt.Sprintf("%s/default.svg", ts.URL),
+	}
+	iconMap, err := fetcher.FetchIcons(b)
+	c.Assert(err, gc.IsNil)
+	c.Assert(iconMap, gc.DeepEquals, map[string][]byte{
+		"~charming-devs/precise/elasticsearch-2": []byte("<svg>default</svg>\n"),
+		"~juju-jitsu/precise/charmworld-58":      []byte("<svg>default</svg>\n"),
+		"precise/mongodb-21":                     []byte("<svg>default</svg>\n"),
+	})
+	// We should have already fetched and received our 404.
+	c.Assert(alreadyFetched, gc.Equals, true)
+	// Call count should be 4, representing the first 404, then the fallbacks.
+	c.Assert(callCount, gc.Equals, 4)
+}
+
+func (s *IconFetcherSuite) TestHTTPBadIconURL(c *gc.C) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad-wolf", http.StatusForbidden)
 		return

--- a/jujusvg_test.go
+++ b/jujusvg_test.go
@@ -97,18 +97,15 @@ func (s *newSuite) TestNewFromBundle(c *gc.C) {
 <circle cx="10" cy="10" r="10" style="stroke:#38B44A;fill:none;stroke-width:2px"/>
 <circle cx="10" cy="10" r="5" style="fill:#38B44A"/>
 </g>
-<g id="icon-1" >
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="icon-1">
 &#x9;&#x9;&#x9;&#x9;&#x9;<svg:image width="96" height="96" xlink:href="http://0.1.2.3/~juju-jitsu/precise/charmworld-58.svg"></svg:image>
-&#x9;&#x9;&#x9;&#x9;</svg:svg></g>
-<g id="icon-2" >
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+&#x9;&#x9;&#x9;&#x9;</svg:svg>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="icon-2">
 &#x9;&#x9;&#x9;&#x9;&#x9;<svg:image width="96" height="96" xlink:href="http://0.1.2.3/~charming-devs/precise/elasticsearch-2.svg"></svg:image>
-&#x9;&#x9;&#x9;&#x9;</svg:svg></g>
-<g id="icon-3" >
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+&#x9;&#x9;&#x9;&#x9;</svg:svg>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="icon-3">
 &#x9;&#x9;&#x9;&#x9;&#x9;<svg:image width="96" height="96" xlink:href="http://0.1.2.3/precise/mongodb-21.svg"></svg:image>
-&#x9;&#x9;&#x9;&#x9;</svg:svg></g>
+&#x9;&#x9;&#x9;&#x9;</svg:svg>
 </defs>
 <g id="relations">
 <line x1="417" y1="189" x2="189" y2="351" stroke="#38B44A" stroke-width="2px" stroke-dasharray="129.85, 20" />
@@ -226,12 +223,9 @@ func (s *newSuite) TestDefaultHTTPFetcher(c *gc.C) {
 <circle cx="10" cy="10" r="10" style="stroke:#38B44A;fill:none;stroke-width:2px"/>
 <circle cx="10" cy="10" r="5" style="fill:#38B44A"/>
 </g>
-<g id="icon-1" >
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg"></svg:svg></g>
-<g id="icon-2" >
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg"></svg:svg></g>
-<g id="icon-3" >
-<svg:svg xmlns:svg="http://www.w3.org/2000/svg"></svg:svg></g>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" id="icon-1"></svg:svg>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" id="icon-2"></svg:svg>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" id="icon-3"></svg:svg>
 </defs>
 <g id="relations">
 <line x1="417" y1="189" x2="189" y2="351" stroke="#38B44A" stroke-width="2px" stroke-dasharray="129.85, 20" />

--- a/svg.go
+++ b/svg.go
@@ -82,7 +82,7 @@ func processIcon(r io.Reader, w io.Writer, id string) error {
 	return nil
 }
 
-// setAttr returns the given attributes with the given attribute name set to
+// setXMLAttr returns the given attributes with the given attribute name set to
 // val, adding an attribute if necessary.
 func setXMLAttr(attrs []xml.Attr, name xml.Name, val string) []xml.Attr {
 	found := false

--- a/svg.go
+++ b/svg.go
@@ -2,7 +2,6 @@ package jujusvg
 
 import (
 	"io"
-	"strings"
 
 	"github.com/juju/xml"
 	"gopkg.in/errgo.v1"
@@ -13,7 +12,10 @@ const svgNamespace = "http://www.w3.org/2000/svg"
 // Process an icon SVG file from a reader, removing anything surrounding
 // the <svg></svg> tags, which would be invalid in this context (such as
 // <?xml...?> decls, directives, etc), writing out to a writer.  In
-// addition, loosely check that the icon is a valid SVG file.
+// addition, loosely check that the icon is a valid SVG file.  The id
+// argument provides a unique identifier for the icon SVG so that it can
+// be referenced within the bundle diagram.  If an id attribute on the SVG
+// tag already exists, it will be replaced with this argument.
 func processIcon(r io.Reader, w io.Writer, id string) error {
 	dec := xml.NewDecoder(r)
 	dec.DefaultSpace = svgNamespace
@@ -35,21 +37,11 @@ func processIcon(r io.Reader, w io.Writer, id string) error {
 		if ok && tag.Name.Space == svgNamespace && tag.Name.Local == "svg" {
 			svgStartFound = true
 			depth++
-			st := tok.(xml.StartElement)
-			for i := range st.Attr {
-				if strings.ToLower(st.Attr[i].Name.Local) == "id" {
-					st.Attr = append(st.Attr[:i], st.Attr[i+1:]...)
-					break
-				}
-			}
-			st.Attr = append(st.Attr, xml.Attr{
-				Name: xml.Name{
-					Local: "id",
-				},
-				Value: id,
-			})
-			if err := enc.EncodeToken(st); err != nil {
-				return errgo.Notef(err, "cannot encode token %#v", st)
+			tag.Attr = setXMLAttr(tag.Attr, xml.Name{
+				Local: "id",
+			}, id)
+			if err := enc.EncodeToken(tag); err != nil {
+				return errgo.Notef(err, "cannot encode token %#v", tag)
 			}
 		}
 	}
@@ -88,4 +80,24 @@ func processIcon(r io.Reader, w io.Writer, id string) error {
 	}
 
 	return nil
+}
+
+// setAttr returns the given attributes with the given attribute name set to
+// val, adding an attribute if necessary.
+func setXMLAttr(attrs []xml.Attr, name xml.Name, val string) []xml.Attr {
+	found := false
+	for i := range attrs {
+		if attrs[i].Name == name {
+			attrs[i].Value = val
+			found = true
+			break
+		}
+	}
+	if !found {
+		attrs = append(attrs, xml.Attr{
+			Name:  name,
+			Value: val,
+		})
+	}
+	return attrs
 }

--- a/svg.go
+++ b/svg.go
@@ -85,19 +85,14 @@ func processIcon(r io.Reader, w io.Writer, id string) error {
 // setXMLAttr returns the given attributes with the given attribute name set to
 // val, adding an attribute if necessary.
 func setXMLAttr(attrs []xml.Attr, name xml.Name, val string) []xml.Attr {
-	found := false
 	for i := range attrs {
 		if attrs[i].Name == name {
 			attrs[i].Value = val
-			found = true
-			break
+			return attrs
 		}
 	}
-	if !found {
-		attrs = append(attrs, xml.Attr{
-			Name:  name,
-			Value: val,
-		})
-	}
-	return attrs
+	return append(attrs, xml.Attr{
+		Name:  name,
+		Value: val,
+	})
 }

--- a/svg_test.go
+++ b/svg_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/juju/xml"
+
 	gc "gopkg.in/check.v1"
 )
 
@@ -137,4 +139,32 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 			assertXMLEqual(c, out.Bytes(), []byte(test.expected))
 		}
 	}
+}
+
+func (s *SVGSuite) TestSetXMLAttr(c *gc.C) {
+	expected := []xml.Attr{
+		{
+			Name: xml.Name{
+				Local: "id",
+			},
+			Value: "foo",
+		},
+	}
+
+	result := setXMLAttr([]xml.Attr{}, xml.Name{
+		Local: "id",
+	}, "foo")
+	c.Assert(result, gc.DeepEquals, expected)
+
+	result = setXMLAttr([]xml.Attr{
+		{
+			Name: xml.Name{
+				Local: "id",
+			},
+			Value: "bar",
+		},
+	}, xml.Name{
+		Local: "id",
+	}, "foo")
+	c.Assert(result, gc.DeepEquals, expected)
 }

--- a/svg_test.go
+++ b/svg_test.go
@@ -2,6 +2,7 @@ package jujusvg
 
 import (
 	"bytes"
+	"fmt"
 
 	gc "gopkg.in/check.v1"
 )
@@ -25,7 +26,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 				</svg>
 				`,
 			expected: `
-				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" id="test-0">
 					<g id="foo"></g>
 				</svg>`,
 		},
@@ -40,7 +41,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 				</svg>
 				`,
 			expected: `
-				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" id="test-1">
 					<svg>
 						<g id="foo"></g>
 					</svg>
@@ -56,7 +57,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 				</svg>
 				`,
 			expected: `
-				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" id="test-2">
 					<g id="foo"></g>
 				</svg>`,
 		},
@@ -69,7 +70,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 				</svg>
 				`,
 			expected: `
-				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" id="test-3">
 					<g id="foo"></g>
 				</svg>`,
 		},
@@ -82,7 +83,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 				<?procinst foo="bar"?>
 				`,
 			expected: `
-				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" id="test-4">
 					<g id="foo"></g>
 				</svg>`,
 		},
@@ -95,7 +96,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 				<!DOCTYPE svg>
 				`,
 			expected: `
-				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" id="test-5">
 					<g id="foo"></g>
 				</svg>`,
 		},
@@ -109,7 +110,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 				</svg>
 				`,
 			expected: `
-				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+				<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" id="test-6">
 					<!DOCTYPE svg>
 					<?proc foo="bar"?>
 					<g id="foo"></g>
@@ -125,10 +126,10 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 			err: "icon does not appear to be a valid SVG",
 		},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		in := bytes.NewBuffer([]byte(test.icon))
 		out := bytes.Buffer{}
-		err := processIcon(in, &out)
+		err := processIcon(in, &out, fmt.Sprintf("test-%d", i))
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		} else {

--- a/svg_test.go
+++ b/svg_test.go
@@ -142,6 +142,7 @@ func (s *SVGSuite) TestProcessIcon(c *gc.C) {
 }
 
 func (s *SVGSuite) TestSetXMLAttr(c *gc.C) {
+	// Attribute is added.
 	expected := []xml.Attr{
 		{
 			Name: xml.Name{
@@ -156,10 +157,57 @@ func (s *SVGSuite) TestSetXMLAttr(c *gc.C) {
 	}, "foo")
 	c.Assert(result, gc.DeepEquals, expected)
 
+	// Attribute is changed.
 	result = setXMLAttr([]xml.Attr{
 		{
 			Name: xml.Name{
 				Local: "id",
+			},
+			Value: "bar",
+		},
+	}, xml.Name{
+		Local: "id",
+	}, "foo")
+	c.Assert(result, gc.DeepEquals, expected)
+
+	// Attribute is changed, existing attributes unchanged.
+	expected = []xml.Attr{
+		{
+			Name: xml.Name{
+				Local: "class",
+			},
+			Value: "bar",
+		},
+		{
+			Name: xml.Name{
+				Local: "id",
+			},
+			Value: "foo",
+		},
+	}
+	result = setXMLAttr([]xml.Attr{
+		{
+			Name: xml.Name{
+				Local: "class",
+			},
+			Value: "bar",
+		},
+		{
+			Name: xml.Name{
+				Local: "id",
+			},
+			Value: "bar",
+		},
+	}, xml.Name{
+		Local: "id",
+	}, "foo")
+	c.Assert(result, gc.DeepEquals, expected)
+
+	// Attribute is added, existing attributes unchanged.
+	result = setXMLAttr([]xml.Attr{
+		{
+			Name: xml.Name{
+				Local: "class",
 			},
 			Value: "bar",
 		},


### PR DESCRIPTION
The following is a  to fix the fact that SVGs in most browsers don't obey viewBox attributes when included via the path of `use -> g -> svg`, but do when included via the path of `use -> svg`. To fix this, we include the icon SVG in the diagram directly, not wrapped in a `<g>`, but that means passing the icon id into `processIcon`. This specifically comes into play with the fact that the default icon on jujucharms.com is 160x160px, but icons are 96x96px, and they will not scale otherwise, but more generally, is good practice to allow icons of any size.