### PR TITLE
move to v3; use charm.v6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifndef GOPATH
 	$(warning You need to set up a GOPATH.)
 endif
 
-PROJECT := gopkg.in/juju/jujusvg.v2
+PROJECT := gopkg.in/juju/jujusvg.v3
 PROJECT_DIR := $(shell go list -e -f '{{.Dir}}' $(PROJECT))
 
 help:

--- a/canvas.go
+++ b/canvas.go
@@ -9,7 +9,7 @@ import (
 
 	svg "github.com/ajstarks/svgo"
 
-	"gopkg.in/juju/jujusvg.v2/assets"
+	"gopkg.in/juju/jujusvg.v3/assets"
 )
 
 const (

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/jujusvg.v2/assets"
+	"gopkg.in/juju/jujusvg.v3/assets"
 )
 
 type CanvasSuite struct{}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,4 +1,5 @@
 github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04T21:11:59Z
+github.com/gabriel-samfira/sys	git	9ddc60d56b511544223adecea68da1e4f2153beb	2015-06-08T13:21:19Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
@@ -12,7 +13,7 @@ github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:1
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/juju/charm.v6-unstable	git	503191ddf2590b15db9669c424660ed612d0a30a	2016-05-27T01:46:20Z
+gopkg.in/juju/charm.v6	git	e03b52c17fcc23dd3154fdda6cbd357c6ded1f01	2017-11-14T08:45:40Z
 gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/yaml.v2	git	a83829b6f1293c91addabc89d0571c246397bbf4	2016-03-01T20:40:22Z

--- a/examples/generatesvg.go
+++ b/examples/generatesvg.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 
 	// Import the jujusvg library and the juju charm library
-	"gopkg.in/juju/jujusvg.v2"
+	"gopkg.in/juju/jujusvg.v3"
 )
 
 // iconURL takes a reference to a charm and returns the URL for that charm's icon.

--- a/iconfetcher.go
+++ b/iconfetcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/utils/parallel"
 	"github.com/juju/xml"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 // An IconFetcher provides functionality for retrieving icons for the charms

--- a/iconfetcher_test.go
+++ b/iconfetcher_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 type IconFetcherSuite struct{}

--- a/jujusvg.go
+++ b/jujusvg.go
@@ -1,4 +1,4 @@
-package jujusvg // import "gopkg.in/juju/jujusvg.v2"
+package jujusvg // import "gopkg.in/juju/jujusvg.v3"
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 // NewFromBundle returns a new Canvas that can be used

--- a/jujusvg_test.go
+++ b/jujusvg_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 func Test(t *testing.T) { gc.TestingT(t) }


### PR DESCRIPTION
This is an automated change, made by running:
 
   govers gopkg.in/juju/charm.v6

As the charm package is exposed in the public API, this is a backwardly
incompatible change so we bump the version to v3.
