### PR TITLE
Remove bad charm.v7 import

### DIFF
--- a/examples/generatesvg.go
+++ b/examples/generatesvg.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/juju/charm.v7-unstable"
+	"gopkg.in/juju/charm.v6"
 
 	// Import the jujusvg library and the juju charm library
 	"gopkg.in/juju/jujusvg.v3"

--- a/iconfetcher.go
+++ b/iconfetcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/utils/parallel"
 	"github.com/juju/xml"
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v7-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 // An IconFetcher provides functionality for retrieving icons for the charms

--- a/jujusvg.go
+++ b/jujusvg.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v7-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 // NewFromBundle returns a new Canvas that can be used


### PR DESCRIPTION
A recent PR added a bad charm.v7 import which doesn't exist.